### PR TITLE
fix inTransaction flg handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.16
+
+- Fix in transaction flag
+
 ## 0.0.15
 
 - Fix capability flags parsing

--- a/lib/src/mysql_client/connection.dart
+++ b/lib/src/mysql_client/connection.dart
@@ -538,6 +538,7 @@ class MySQLConnection {
     try {
       final result = await callback(this);
       await execute("COMMIT");
+      _inTransaction = false;
       return result;
     } catch (e) {
       await execute("ROLLBACK");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mysql_client
 description: Native MySQL client written in Dart. Tested with MySQL Percona Server (5.7, 8), MariaDB (10). Supports TLS.
-version: 0.0.15
+version: 0.0.16
 homepage: https://github.com/zim32/mysql.dart
 repository: https://github.com/zim32/mysql.dart
 platforms:

--- a/test/mysql_client.dart
+++ b/test/mysql_client.dart
@@ -251,6 +251,36 @@ create table book
     },
   );
 
+  test("testing double transaction", () async {
+    try {
+      await conn.transactional<void>((conn) async {
+        await conn.execute("SELECT * FROM book");
+      });
+      await conn.transactional<void>((conn) async {
+        await conn.execute("SELECT * FROM book");
+      });
+    } catch (e) {
+      fail("Exception is thrown");
+    }
+  });
+
+  test("testing error is thrown if prevent double transaction", () async {
+    try {
+      await Future.wait([
+        conn.transactional<void>((conn) async {
+          await conn.execute("SELECT * FROM book");
+        }),
+        conn.transactional<void>((conn) async {
+          await conn.execute("SELECT * FROM book");
+        }),
+      ]);
+      fail("Exception is not thrown");
+    } catch (e) {
+      expect(e, isA<Exception>());
+      expect(e.toString(), "Exception: Already in transaction");
+    }
+  });
+
   test(
     "testing missing param",
     () async {


### PR DESCRIPTION
I use this package for private projects.
When I tried to use transaction, encountered a control I did not expect.

Isn't `COMMIT` after `_inTransaction = false;` ...?
It is possible that the intent of the control is not properly understood.

Thanks for the great package. I support the long term development of this package.

The following expressions are also possible.

```dart
try {
  final result = await callback(this);
  await execute("COMMIT");
  return result;
} catch {
  await execute("ROLLBACK");
  rethrow;
} finally {
  _inTransaction = false;
}
```