### PR TITLE
Add SecurityContext to connection for better TLS handling

### DIFF
--- a/lib/src/mysql_client/connection.dart
+++ b/lib/src/mysql_client/connection.dart
@@ -79,6 +79,7 @@ class MySQLConnection {
     required String userName,
     required String password,
     bool secure = true,
+    SecurityContext? securityContext,
     String? databaseName,
     String collation = 'utf8mb4_general_ci',
   }) async {
@@ -95,6 +96,7 @@ class MySQLConnection {
       password: password,
       databaseName: databaseName,
       secure: secure,
+      securityContext: securityContext,
       collation: collation,
     );
 

--- a/lib/src/mysql_client/connection.dart
+++ b/lib/src/mysql_client/connection.dart
@@ -32,6 +32,7 @@ class MySQLConnection {
   final List<void Function()> _onCloseCallbacks = [];
   bool _inTransaction = false;
   final bool _secure;
+  final SecurityContext? _securityContext;
   final List<int> _incompleteBufferData = [];
   Object? _lastError;
   int _serverCapabilities = 0;
@@ -44,12 +45,14 @@ class MySQLConnection {
     required String password,
     required String collation,
     bool secure = true,
+    SecurityContext? securityContext,
     String? databaseName,
   })  : _socket = socket,
         _username = username,
         _password = password,
         _databaseName = databaseName,
         _secure = secure,
+        _securityContext = securityContext,
         _collation = collation;
 
   /// Creates connection with provided options.
@@ -359,7 +362,8 @@ class MySQLConnection {
 
         final secureSocket = await SecureSocket.secure(
           _socket,
-          onBadCertificate: (certificate) => true,
+          context: _securityContext,
+          onBadCertificate: (certificate) => _securityContext == null,
         );
 
         // switch socket

--- a/lib/src/mysql_client/pool.dart
+++ b/lib/src/mysql_client/pool.dart
@@ -126,6 +126,7 @@ class MySQLConnectionPool {
         password: _password,
         databaseName: databaseName,
         secure: secure,
+        securityContext: securityContext,
         collation: collation,
       );
 

--- a/lib/src/mysql_client/pool.dart
+++ b/lib/src/mysql_client/pool.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:mysql_client/mysql_client.dart';
 
 /// Class to create and manage pool of database connections
@@ -10,6 +11,7 @@ class MySQLConnectionPool {
   final int maxConnections;
   final String? databaseName;
   final bool secure;
+  final SecurityContext? securityContext;
   final String collation;
   final int timeoutMs;
 
@@ -29,6 +31,7 @@ class MySQLConnectionPool {
     required this.maxConnections,
     this.databaseName,
     this.secure = true,
+    this.securityContext,
     this.collation = 'utf8_general_ci',
     this.timeoutMs = 10000,
   }) : _password = password;


### PR DESCRIPTION
this library accepts all tls connections by default, its good we can control this behavior for example to implement key pinning.
